### PR TITLE
Fix: :fire: fix socket listen bug

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -26,7 +26,7 @@ app.io.attach(server);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+server.listen(port, "0.0.0.0");
 server.on('error', onError);
 server.on('listening', onListening);
 


### PR DESCRIPTION
 프론트 서버와 알림 서버가 같은 컴퓨터 내에 있을 때, 로컬에서만 동작하는 이유가 외부 아이피 접속 허용을 안해놨기 때문. 따라서 0.0.0.0 으로 하여 모든 아이피의 송신을 listen 함으로써 해결